### PR TITLE
Fix clip device assignment logic in ApplyFluxIPAdapter

### DIFF
--- a/nodes.py
+++ b/nodes.py
@@ -501,10 +501,14 @@ class ApplyFluxIPAdapter:
             #image = torch.permute(image, (0, ))
             #print(image.shape)
             #print(image)
-            clip_device = next(clip.model.parameters()).device
-            image = torch.clip(image*255, 0.0, 255)
+            if isinstance(clip, torch.nn.Module):
+                clip_device = next(clip.parameters()).device
+            else:
+                clip_device = torch.device('cuda' if torch.cuda.is_available() else 'cpu')
+            image = torch.clip(image * 255, 0.0, 255)
             out = clip(image).to(dtype=torch.bfloat16)
             neg_out = clip(torch.zeros_like(image)).to(dtype=torch.bfloat16)
+
         else:
             print("Using old vit clip")
             clip_device = next(clip.parameters()).device


### PR DESCRIPTION
fixed an AttributeError by adding a check to see if FluxClipViT is a torch model. if it’s not, it defaults to using cuda or cpu, for me it fixes #81 