### PR TITLE
rm text_scale -- same problem as 72e6d2, different node

### DIFF
--- a/nodes.py
+++ b/nodes.py
@@ -736,7 +736,7 @@ class ApplyAdvancedFluxIPAdapter:
 
         ipad_blocks = []
         for i, block in enumerate(ip_adapter_flux['double_blocks']):
-            ipad = IPProcessor(block.context_dim, block.hidden_dim, ip_projes, strength_model[i], text_scale)
+            ipad = IPProcessor(block.context_dim, block.hidden_dim, ip_projes, strength_model[i])
             ipad.load_state_dict(block.state_dict())
             ipad.in_hidden_states_neg = ip_neg_pr
             ipad.in_hidden_states_pos = ip_projes


### PR DESCRIPTION
This was fixed for ApplyFluxIPAdapter in 72e6d2f; this is the same issue, but for ApplyAdvancedFluxIPAdapter.